### PR TITLE
Not sure why spec/ requests, routing, and views are .gitignore'd

### DIFF
--- a/files/gitignore.txt
+++ b/files/gitignore.txt
@@ -45,9 +45,6 @@ db/*.sqlite3
 /capybara*
 /capybara-*.html
 /gems
-/spec/requests
-/spec/routing
-/spec/views
 /specifications
 rerun.txt
 pickle-email-*.html


### PR DESCRIPTION
Daniel ~

Is there some reason (I can't seem to fathom one) as to why you'd not want these specs in the repos for anyone who uses Rails Composer?  (Or more likely, just an oversight that they were left in your .gitignore?)  :-)

This pull request removes the .gitignore'ing of these specs.  I didn't change the project one, because I'm guessing you don't write request, routing, or view specs (though it still seems strange that you'd .gitignore them, even if you don't write them), but many folks after using Rails Composer to build a skeleton app may very well do so themselves.

Cheers
~ Brad
