### PR TITLE
binding_of_caller only works in MRI 1.9.2-3 and RBX

### DIFF
--- a/composer.rb
+++ b/composer.rb
@@ -2133,6 +2133,7 @@ end
 if prefs[:better_errors]
   say_wizard "recipe adding better_errors gem"
   gem 'better_errors', '>= 0.6.0', :group => :development
+  gem 'binding_of_caller', '>= 0.6.9', :group => :development, :platforms => [:mri_19, :rbx]
 end
 
 ## BAN SPIDERS


### PR DESCRIPTION
I added a :platforms group to the binding_of_caller gem to prevent it from being installed in non-MRI/Rubinius Ruby implementations (JRuby, et al)

https://github.com/banister/binding_of_caller

http://gembundler.com/man/gemfile.5.html
