### PR TITLE
Remove dependency from lib v8 for latest therubyracer version

### DIFF
--- a/composer.rb
+++ b/composer.rb
@@ -895,8 +895,7 @@ if prefer :bootstrap, 'less'
   add_gem 'less-rails', :group => :assets
   add_gem 'twitter-bootstrap-rails', :group => :assets
   # install gem 'therubyracer' to use Less
-  #add_gem 'libv8'
-  add_gem 'therubyracer', :group => :assets, :platform => :ruby  #, :require => 'v8'
+  add_gem 'therubyracer', :group => :assets, :platform => :ruby
 end
 
 ## Email
@@ -2467,8 +2466,7 @@ case RbConfig::CONFIG['host_os']
       # was it already added for bootstrap-less?
       unless prefer :bootstrap, 'less'
         say_wizard "recipe adding 'therubyracer' JavaScript runtime gem"
-        #add_gem 'libv8'
-        add_gem 'therubyracer', :group => :assets, :platform => :ruby   #, :require => 'v8'
+        add_gem 'therubyracer', :group => :assets, :platform => :ruby 
       end
     end
 end


### PR DESCRIPTION
Dear,
I have removed the dependency from the v8 lib due the last therubyracer package does not require them and the rails-composer fails to generate the application.
