### PR TITLE
Readme markdown

### DIFF
--- a/files/README.md
+++ b/files/README.md
@@ -58,6 +58,8 @@ Email
 
 The application is configured to send email using a Gmail account.
 
+Email delivery is disabled in development.
+
 Getting Started
 ---------------
 


### PR DESCRIPTION
This goes along with https://github.com/RailsApps/rails_apps_composer/pull/276. Changed default README.textile to README.md, and updated how new admin and email_dev recipes are added to the readme.
