### PR TITLE
Added .env and .powenv to .gitignore

### DIFF
--- a/files/gitignore.txt
+++ b/files/gitignore.txt
@@ -77,3 +77,7 @@ pickle-email-*.html
 
 # vim artifacts
 **.swp
+
+# Environment files that may contain sensitive data
+.env
+.powenv


### PR DESCRIPTION
Many times .env files are used to contain sensitive data (API_KEYs, etc.) so I think it makes sense to ignore them by default
