### PR TITLE
tiny improvements

### DIFF
--- a/composer.rb
+++ b/composer.rb
@@ -946,7 +946,8 @@ end
 
 stage_two do
   unless prefer :locale, 'none'
-    gsub_file 'config/application.rb', /# config.i18n.default_locale.*$/, "config.i18n.default_locale = :#{prefs[:locale]}"
+    locale_for_app = prefs[:locale].include?('-') ? "'#{prefs[:locale]}'" : prefs[:locale]
+    gsub_file 'config/application.rb', /# config.i18n.default_locale.*$/, "config.i18n.default_locale = :#{locale_for_app}"
     locale_filename = "config/locales/#{prefs[:locale]}.yml"
     create_file locale_filename
     append_to_file locale_filename, "#{prefs[:locale]}:"


### PR DESCRIPTION
- Now that spring is default in Rails, when I opt for rspec I would like to also use it when running tests.
- When a locale has a -, as in pt-BR it must be written as :'pt-BR' in config/application.rb
