### PR TITLE
Add .alert-dismissible to Bootstrap flash messages

### DIFF
--- a/files/app/views/layouts/_messages-bootstrap.html.erb
+++ b/files/app/views/layouts/_messages-bootstrap.html.erb
@@ -1,6 +1,6 @@
 <% flash.each do |name, msg| %>
   <% if msg.is_a?(String) %>
-    <div class="alert alert-<%= name == :notice ? "success" : "error" %>">
+    <div class="alert alert-dismissible alert-<%= name == :notice ? "success" : "error" %>">
       <a class="close" data-dismiss="alert">&#215;</a>
       <%= content_tag :div, msg, :id => "flash_#{name}" %>
     </div>


### PR DESCRIPTION
The .alert-dismissible class adds some extra styling to the alert div, most importantly the rule "top: -2px" which vertically centers the &#215; character in the alert div.
