### PR TITLE
Gem mysql2 version modification

### DIFF
--- a/composer.rb
+++ b/composer.rb
@@ -1534,7 +1534,7 @@ end
 gsub_file 'Gemfile', /gem 'pg'.*/, ''
 add_gem 'pg' if prefer :database, 'postgresql'
 gsub_file 'Gemfile', /gem 'mysql2'.*/, ''
-add_gem 'mysql2' if prefer :database, 'mysql'
+add_gem 'mysql2', '~> 0.3.18' if prefer :database, 'mysql'
 
 ## Gem to set up controllers, views, and routing in the 'apps4' recipe
 add_gem 'rails_apps_pages', :group => :development if prefs[:apps4]


### PR DESCRIPTION
Hi Daniel,
I like your composer. It is great work!
I have issue with composer for ruby 2.2.3 and rails 4.2.4.

 When I build a custom application with mуsql database, I see error:
...
Specified 'mysql2' for database adapter, but the gem is not loaded. Add `gem 'mysql2'` to your Gemfile (and ensure its version is at the minimum required by ActiveRecord).

...
Such a case is described in:

http://stackoverflow.com/questions/22932282/gemloaderror-specified-mysql2-for-database-adapter-but-the-gem-is-not-loade

When I use gem 'mysql2', '~> 0.3.18', I see connection to database.

I try to edit composer. You can see last commit on  https://github.com/alexponi/rails-composer

When I run command

rails new . -m https://raw.github.com/alexponi/rails-composer/master/composer.rb

it is worked.

Kind regards,

Alexander Ponikarovsky.